### PR TITLE
Convert all Vue components to script setup syntax

### DIFF
--- a/src/components/Mfm.vue
+++ b/src/components/Mfm.vue
@@ -16,30 +16,16 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 // class と className が混在してるのやばそう
 import { getComponent } from '../utils/mfmUtil.ts'
-import { defineComponent } from 'vue'
 
-export default defineComponent({
-  data() {
-    return {
-      debugMode: this.debugMode
-    }
-  },
-  props: {
-    tokens: {
-      required: true,
-      type: Object
-    },
-    style: Object,
-    className: String,
-    class: String
-  },
-  methods: {
-    getComponent
-  }
-})
+defineProps<{
+  tokens: any
+  style?: object
+  className?: string
+  class?: string
+}>()
 </script>
 
 <style scoped></style>

--- a/src/components/MfmAst.vue
+++ b/src/components/MfmAst.vue
@@ -2,23 +2,15 @@
   <pre>{{ parsedMfm }}</pre>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { mfm } from '../utils/mfmUtil.ts'
-import { defineComponent } from 'vue'
+import { computed } from 'vue'
 
-export default defineComponent({
-  props: {
-    text: {
-      required: true,
-      type: String
-    }
-  },
-  computed: {
-    parsedMfm() {
-      return mfm(this.text, false)
-    }
-  }
-})
+const props = defineProps<{
+  text: string
+}>()
+
+const parsedMfm = computed(() => mfm(props.text, false))
 </script>
 
 <style scoped></style>

--- a/src/components/MfmComponents/BlockCode.vue
+++ b/src/components/MfmComponents/BlockCode.vue
@@ -5,9 +5,12 @@
   </pre>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 // lang が与えられたらハイライトとか
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>

--- a/src/components/MfmComponents/Bold.vue
+++ b/src/components/MfmComponents/Bold.vue
@@ -2,8 +2,8 @@
   <b class="bold"><MfmComponent :tokens="children" /></b>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['children']
-}
+<script setup lang="ts">
+defineProps<{
+  children?: any
+}>()
 </script>

--- a/src/components/MfmComponents/Center.vue
+++ b/src/components/MfmComponents/Center.vue
@@ -4,10 +4,12 @@
   </div>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['children', 'class', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  children?: any
+  class?: string
+  className?: string
+}>()
 </script>
 <style>
 .center {

--- a/src/components/MfmComponents/EmojiCode.vue
+++ b/src/components/MfmComponents/EmojiCode.vue
@@ -4,18 +4,18 @@
   <!--  <img class="emoji" :src="emoji()" />-->
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+import { inject } from 'vue'
 
-export default defineComponent({
-  inject: ['emojis'],
-  data() {
-    return {
-      emojis: this.emojis as Record<string, any>
-    }
-  },
-  props: ['token', 'children', 'className', 'class', 'style']
-})
+defineProps<{
+  token?: any
+  children?: any
+  className?: string
+  class?: string
+  style?: object
+}>()
+
+const emojis = inject<Record<string, any>>('emojis', {})
 </script>
 
 <style scoped>

--- a/src/components/MfmComponents/Fn.vue
+++ b/src/components/MfmComponents/Fn.vue
@@ -8,13 +8,16 @@
   />
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { getComponent } from '../../utils/mfmUtil.ts'
 
-export default {
-  methods: { getComponent },
-  props: ['token', 'tokens', 'children', 'style', 'className']
-}
+defineProps<{
+  token?: any
+  tokens?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style>

--- a/src/components/MfmComponents/Fn/Bg.vue
+++ b/src/components/MfmComponents/Fn/Bg.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Blur.vue
+++ b/src/components/MfmComponents/Fn/Blur.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style>

--- a/src/components/MfmComponents/Fn/Bounce.vue
+++ b/src/components/MfmComponents/Fn/Bounce.vue
@@ -14,10 +14,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Fg.vue
+++ b/src/components/MfmComponents/Fn/Fg.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Flip.vue
+++ b/src/components/MfmComponents/Fn/Flip.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Jelly.vue
+++ b/src/components/MfmComponents/Fn/Jelly.vue
@@ -13,10 +13,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Jump.vue
+++ b/src/components/MfmComponents/Fn/Jump.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Position.vue
+++ b/src/components/MfmComponents/Fn/Position.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Rainbow.vue
+++ b/src/components/MfmComponents/Fn/Rainbow.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Rotate.vue
+++ b/src/components/MfmComponents/Fn/Rotate.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Ruby.vue
+++ b/src/components/MfmComponents/Fn/Ruby.vue
@@ -5,19 +5,23 @@
   </ruby>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['children', 'token', 'style', 'className'],
-  computed: {
-    ruby() {
-      const ruby = this.children[0].props.text.split(' ')
-      return {
-        body: ruby[0],
-        yomi: ruby[1]
-      }
-    }
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  children?: any
+  token?: any
+  style?: object
+  className?: string
+}>()
+
+const ruby = computed(() => {
+  const rubyText = props.children[0].props.text.split(' ')
+  return {
+    body: rubyText[0],
+    yomi: rubyText[1]
   }
-}
+})
 </script>
 
 <style scoped></style>

--- a/src/components/MfmComponents/Fn/Scale.vue
+++ b/src/components/MfmComponents/Fn/Scale.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Shake.vue
+++ b/src/components/MfmComponents/Fn/Shake.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Spin.vue
+++ b/src/components/MfmComponents/Fn/Spin.vue
@@ -20,10 +20,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Tada.vue
+++ b/src/components/MfmComponents/Fn/Tada.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/Twitch.vue
+++ b/src/components/MfmComponents/Fn/Twitch.vue
@@ -11,10 +11,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/font.vue
+++ b/src/components/MfmComponents/Fn/font.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/x2.vue
+++ b/src/components/MfmComponents/Fn/x2.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/x3.vue
+++ b/src/components/MfmComponents/Fn/x3.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Fn/x4.vue
+++ b/src/components/MfmComponents/Fn/x4.vue
@@ -6,10 +6,13 @@
   />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style></style>

--- a/src/components/MfmComponents/Hashtag.vue
+++ b/src/components/MfmComponents/Hashtag.vue
@@ -2,8 +2,10 @@
   <a class="hashtag" :href="'/tags/' + token.hashtag">#{{ token.hashtag }}</a>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+}>()
 </script>

--- a/src/components/MfmComponents/Inlinecode.vue
+++ b/src/components/MfmComponents/Inlinecode.vue
@@ -2,8 +2,11 @@
   <pre class="inline-code">{{ token.code }}</pre>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 </script>

--- a/src/components/MfmComponents/Italic.vue
+++ b/src/components/MfmComponents/Italic.vue
@@ -2,8 +2,8 @@
   <i class="italic"><MfmComponent :tokens="children" /></i>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['children']
-}
+<script setup lang="ts">
+defineProps<{
+  children?: any
+}>()
 </script>

--- a/src/components/MfmComponents/Link.vue
+++ b/src/components/MfmComponents/Link.vue
@@ -5,34 +5,18 @@
   </a>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue'
+<script setup lang="ts">
+import { inject } from 'vue'
 
-export default defineComponent({
-  inject: ['debugMode'],
-  data() {
-    return {
-      debugMode: this.debugMode
-    }
-  },
-  props: {
-    token: {
-      type: Object as PropType<any>
-    },
-    children: {
-      type: Object
-    },
-    className: {
-      type: String
-    },
-    style: {
-      type: Object
-    },
-    class: {
-      type: String
-    }
-  }
-})
+defineProps<{
+  token?: any
+  children?: object
+  className?: string
+  style?: object
+  class?: string
+}>()
+
+const debugMode = inject('debugMode', false)
 </script>
 
 <style scoped></style>

--- a/src/components/MfmComponents/Mention.vue
+++ b/src/components/MfmComponents/Mention.vue
@@ -4,43 +4,41 @@
   >
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+import { inject, ref, watch } from 'vue'
 
-export default defineComponent({
-  props: ['token', 'children', 'style', 'className'],
-  inject: ['domain'],
-  data() {
-    return {
-      domain: this.domain,
-      user: undefined as unknown as any
-    }
-  },
-  watch: {
-    token: {
-      immediate: true,
-      async handler() {
-        // FIXME: なんかバウンスとかスロットルとか必要
-        const res = await fetch(
-          `https:/${this.token.host ?? this.domain}/api/users/search-by-username-and-host`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json; charset=utf-8'
-            },
-            body: JSON.stringify({
-              detail: false,
-              limit: 1,
+const props = defineProps<{
+  token?: any
+  children?: any
+  style?: object
+  className?: string
+}>()
 
-              username: this.token.username
-            })
-          }
-        )
-        this.user = (await res.json())[0]
+const domain = inject<any>('domain', '')
+const user = ref<any>(undefined)
+
+watch(
+  () => props.token,
+  async () => {
+    // FIXME: なんかバウンスとかスロットルとか必要
+    const res = await fetch(
+      `https:/${props.token.host ?? domain.value}/api/users/search-by-username-and-host`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8'
+        },
+        body: JSON.stringify({
+          detail: false,
+          limit: 1,
+          username: props.token.username
+        })
       }
-    }
-  }
-})
+    )
+    user.value = (await res.json())[0]
+  },
+  { immediate: true }
+)
 </script>
 
 <style>

--- a/src/components/MfmComponents/Plain.vue
+++ b/src/components/MfmComponents/Plain.vue
@@ -2,10 +2,13 @@
   <MfmComponent :tokens="children" />
 </template>
 
-<script lang="ts">
-export default {
-  props: ['children', 'token', 'style', 'className']
-}
+<script setup lang="ts">
+defineProps<{
+  children?: any
+  token?: any
+  style?: object
+  className?: string
+}>()
 </script>
 
 <style scoped></style>

--- a/src/components/MfmComponents/Quote.vue
+++ b/src/components/MfmComponents/Quote.vue
@@ -14,8 +14,8 @@
   </div>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['children']
-}
+<script setup lang="ts">
+defineProps<{
+  children?: any
+}>()
 </script>

--- a/src/components/MfmComponents/Search.vue
+++ b/src/components/MfmComponents/Search.vue
@@ -4,32 +4,23 @@
   </div>
 </template>
 
-<script lang="ts">
-import { PropType } from 'vue'
+<script setup lang="ts">
+import { ref } from 'vue'
 
-export default {
-  data() {
-    return {
-      currentQuery: this.token.query
-    }
-  },
-  props: {
-    token: {
-      type: Object as PropType<{ query: string }>,
-      required: true
-    },
-    children: {
-      type: Object
-    }
-  },
-  methods: {
-    search() {
-      window.open(
-        'https://www.google.com/search?q=' + encodeURIComponent(this.currentQuery),
-        '_blank'
-      )
-    }
-  }
+interface Props {
+  token: { query: string }
+  children?: object
+}
+
+const props = defineProps<Props>()
+
+const currentQuery = ref(props.token.query)
+
+const search = () => {
+  window.open(
+    'https://www.google.com/search?q=' + encodeURIComponent(currentQuery.value),
+    '_blank'
+  )
 }
 </script>
 

--- a/src/components/MfmComponents/Small.vue
+++ b/src/components/MfmComponents/Small.vue
@@ -2,9 +2,11 @@
   <small class="small" style="opacity: 0.7"><MfmComponent :tokens="children" /></small>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 // smallが再帰を起こさないのは割りと謎
-export default {
-  props: ['children', 'token', 'style']
-}
+defineProps<{
+  children?: any
+  token?: any
+  style?: object
+}>()
 </script>

--- a/src/components/MfmComponents/Strike.vue
+++ b/src/components/MfmComponents/Strike.vue
@@ -2,8 +2,9 @@
   <del class="strike"><MfmComponent :tokens="children" /></del>
 </template>
 
-<script lang="ts">
-export default {
-  props: ['token', 'children']
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: any
+}>()
 </script>

--- a/src/components/MfmComponents/Text.vue
+++ b/src/components/MfmComponents/Text.vue
@@ -5,40 +5,35 @@
   </template>
 </template>
 
-<script lang="ts">
-import { PropType } from 'vue'
+<script setup lang="ts">
+import { computed } from 'vue'
 
-export default {
-  props: {
-    children: Object,
-    token: Object as PropType<any>,
-    plain: {
-      type: Boolean,
-      default: false
-    },
-    className: String,
-    nowrap: {
-      type: Boolean,
-      default: false
-    },
-    note: Object,
-    style: Object
-  },
-  methods: {
-    showBr(_text: string, index: number) {
-      // 行末では改行しない
-      if (index + 1 === this.parsedText.length) {
-        return false
-      }
+interface Props {
+  children?: object
+  token?: any
+  plain?: boolean
+  className?: string
+  nowrap?: boolean
+  note?: object
+  style?: object
+}
 
-      return true
-    }
-  },
-  computed: {
-    parsedText() {
-      if (!this.plain) return this.token.text.split(/\r\n|\n|\r/)
-      return [this.token.text.replace(/\n/g, ' ')]
-    }
+const props = withDefaults(defineProps<Props>(), {
+  plain: false,
+  nowrap: false
+})
+
+const parsedText = computed(() => {
+  if (!props.plain) return props.token.text.split(/\r\n|\n|\r/)
+  return [props.token.text.replace(/\n/g, ' ')]
+})
+
+const showBr = (_text: string, index: number) => {
+  // 行末では改行しない
+  if (index + 1 === parsedText.value.length) {
+    return false
   }
+
+  return true
 }
 </script>

--- a/src/components/MfmComponents/UnicodeEmoji.vue
+++ b/src/components/MfmComponents/UnicodeEmoji.vue
@@ -2,11 +2,14 @@
   <span :style="style">{{ token.emoji }}</span>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 // 本当は twimojiやfluent emojiに置き換える
-export default {
-  props: ['children', 'token', 'class', 'style']
-}
+defineProps<{
+  children?: any
+  token?: any
+  class?: string
+  style?: object
+}>()
 </script>
 
 <style scoped></style>

--- a/src/components/MfmComponents/Url.vue
+++ b/src/components/MfmComponents/Url.vue
@@ -2,20 +2,11 @@
   <a class="url" :href="token.url" v-text="token.url" />
 </template>
 
-<script lang="ts">
-import { PropType } from 'vue'
-
-export default {
-  name: 'Url.vue',
-  props: {
-    token: {
-      type: Object as PropType<any>
-    },
-    children: {
-      type: Object
-    }
-  }
-}
+<script setup lang="ts">
+defineProps<{
+  token?: any
+  children?: object
+}>()
 </script>
 
 <style scoped></style>

--- a/src/components/MfmRenderer.vue
+++ b/src/components/MfmRenderer.vue
@@ -2,27 +2,16 @@
   <MfmComponent :tokens="parsedMfm" />
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { mfm } from '../utils/mfmUtil.ts'
-import { defineComponent } from 'vue'
+import { computed } from 'vue'
 import MfmComponent from './Mfm.vue'
 
-export default defineComponent({
-  components: {
-    MfmComponent
-  },
-  props: {
-    text: {
-      required: true,
-      type: String
-    }
-  },
-  computed: {
-    parsedMfm() {
-      return mfm(this.text, false)
-    }
-  }
-})
+const props = defineProps<{
+  text: string
+}>()
+
+const parsedMfm = computed(() => mfm(props.text, false))
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## Summary

Converted all 41 Vue components from Options API to Composition API with `<script setup>` syntax.

Closes #3

## Changes

- Converted main components (App.vue, MfmRenderer.vue, Mfm.vue, MfmAst.vue)
- Converted all MfmComponents (Bold, Italic, Strike, Small, etc.)
- Converted all Fn components (Bg, Blur, Position, Flip, etc.)
- Replaced `defineComponent` with `defineProps` and `<script setup>`
- Converted data, computed, methods, and watch to Composition API equivalents
- Maintained all functionality while improving code readability

Generated with [Claude Code](https://claude.ai/code)