### PR TITLE
docs: add ruby component to README.md Fn table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ createApp(App).use(Mfm).mount('#app')
 | rotate    | 回転          | よさそう         |
 | scale     | 拡大          | よさそう         |
 | position  | 位置変更        | よさそう         |
+| ruby      | ルビ（ふりがな）  | よさそう         |
 | （アニメーション) |             | delay 以外よさそう |
 | sparkle   | きらきら        | 未実装          |
 | unixtime  | 相対時間        | 未実装          | 


### PR DESCRIPTION
Ruby component was already implemented but missing from the documentation.

Closes #7

Generated with [Claude Code](https://claude.ai/code)