### PR TITLE
fix: TypeScript型エラーを修正

### DIFF
--- a/src/components/Mfm.vue
+++ b/src/components/Mfm.vue
@@ -18,14 +18,18 @@
 
 <script setup lang="ts">
 // class と className が混在してるのやばそう
+import type { CSSProperties } from 'vue'
 import { getComponent } from '../utils/mfmUtil.ts'
 
-defineProps<{
+const props = defineProps<{
   tokens: any
-  style?: object
+  style?: CSSProperties
   className?: string
   class?: string
+  debug?: boolean
 }>()
+
+const debugMode = props.debug ? true : false
 </script>
 
 <style scoped></style>

--- a/src/components/MfmComponents/BlockCode.vue
+++ b/src/components/MfmComponents/BlockCode.vue
@@ -7,10 +7,12 @@
 
 <script setup lang="ts">
 // lang が与えられたらハイライトとか
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/EmojiCode.vue
+++ b/src/components/MfmComponents/EmojiCode.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { inject } from 'vue'
 
 defineProps<{
@@ -12,7 +13,7 @@ defineProps<{
   children?: any
   className?: string
   class?: string
-  style?: object
+  style?: CSSProperties
 }>()
 
 const emojis = inject<Record<string, any>>('emojis', {})

--- a/src/components/MfmComponents/Fn.vue
+++ b/src/components/MfmComponents/Fn.vue
@@ -9,13 +9,14 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { getComponent } from '../../utils/mfmUtil.ts'
 
 defineProps<{
   token?: any
   tokens?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Bg.vue
+++ b/src/components/MfmComponents/Fn/Bg.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Blur.vue
+++ b/src/components/MfmComponents/Fn/Blur.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Bounce.vue
+++ b/src/components/MfmComponents/Fn/Bounce.vue
@@ -15,10 +15,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Fg.vue
+++ b/src/components/MfmComponents/Fn/Fg.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Flip.vue
+++ b/src/components/MfmComponents/Fn/Flip.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Font.vue
+++ b/src/components/MfmComponents/Fn/Font.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Jelly.vue
+++ b/src/components/MfmComponents/Fn/Jelly.vue
@@ -14,10 +14,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Jump.vue
+++ b/src/components/MfmComponents/Fn/Jump.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Position.vue
+++ b/src/components/MfmComponents/Fn/Position.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Rainbow.vue
+++ b/src/components/MfmComponents/Fn/Rainbow.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Rotate.vue
+++ b/src/components/MfmComponents/Fn/Rotate.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Ruby.vue
+++ b/src/components/MfmComponents/Fn/Ruby.vue
@@ -6,12 +6,13 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { computed } from 'vue'
 
 const props = defineProps<{
   children?: any
   token?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 

--- a/src/components/MfmComponents/Fn/Scale.vue
+++ b/src/components/MfmComponents/Fn/Scale.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Shake.vue
+++ b/src/components/MfmComponents/Fn/Shake.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Spin.vue
+++ b/src/components/MfmComponents/Fn/Spin.vue
@@ -21,10 +21,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Tada.vue
+++ b/src/components/MfmComponents/Fn/Tada.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/Twitch.vue
+++ b/src/components/MfmComponents/Fn/Twitch.vue
@@ -12,10 +12,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/X2.vue
+++ b/src/components/MfmComponents/Fn/X2.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/X3.vue
+++ b/src/components/MfmComponents/Fn/X3.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Fn/X4.vue
+++ b/src/components/MfmComponents/Fn/X4.vue
@@ -7,10 +7,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Hashtag.vue
+++ b/src/components/MfmComponents/Hashtag.vue
@@ -3,9 +3,11 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
 }>()
 </script>

--- a/src/components/MfmComponents/InlineCode.vue
+++ b/src/components/MfmComponents/InlineCode.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Link.vue
+++ b/src/components/MfmComponents/Link.vue
@@ -6,13 +6,14 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { inject } from 'vue'
 
 defineProps<{
   token?: any
   children?: object
   className?: string
-  style?: object
+  style?: CSSProperties
   class?: string
 }>()
 

--- a/src/components/MfmComponents/Mention.vue
+++ b/src/components/MfmComponents/Mention.vue
@@ -5,12 +5,13 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { inject, ref, watch } from 'vue'
 
 const props = defineProps<{
   token?: any
   children?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 

--- a/src/components/MfmComponents/Plain.vue
+++ b/src/components/MfmComponents/Plain.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   children?: any
   token?: any
-  style?: object
+  style?: CSSProperties
   className?: string
 }>()
 </script>

--- a/src/components/MfmComponents/Small.vue
+++ b/src/components/MfmComponents/Small.vue
@@ -4,9 +4,11 @@
 
 <script setup lang="ts">
 // smallが再帰を起こさないのは割りと謎
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   children?: any
   token?: any
-  style?: object
+  style?: CSSProperties
 }>()
 </script>

--- a/src/components/MfmComponents/Text.vue
+++ b/src/components/MfmComponents/Text.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { computed } from 'vue'
 
 interface Props {
@@ -15,7 +16,7 @@ interface Props {
   className?: string
   nowrap?: boolean
   note?: object
-  style?: object
+  style?: CSSProperties
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/MfmComponents/UnicodeEmoji.vue
+++ b/src/components/MfmComponents/UnicodeEmoji.vue
@@ -4,11 +4,13 @@
 
 <script setup lang="ts">
 // 本当は twimojiやfluent emojiに置き換える
+import type { CSSProperties } from 'vue'
+
 defineProps<{
   children?: any
   token?: any
   class?: string
-  style?: object
+  style?: CSSProperties
 }>()
 </script>
 


### PR DESCRIPTION
## 概要

TypeScriptの型エラーを修正しました。

## 変更内容

1. **CSSスタイルの型修正**: `style?: object` を `style?: CSSProperties` に変更
2. **import文の追加**: `import type { CSSProperties } from 'vue'` を追加
3. **Mfm.vueのdebug修正**: `debug?: boolean` propを追加し、`debugMode` を適切に処理

## 修正したファイル

32個のVueコンポーネントを修正しました。

Closes #14

Generated with [Claude Code](https://claude.ai/code)