### PR TITLE
fix: Fnコンポーネントのクラス名誤り修正

### DIFF
--- a/src/components/MfmComponents/Fn/Bounce.vue
+++ b/src/components/MfmComponents/Fn/Bounce.vue
@@ -1,6 +1,6 @@
 <template>
   <MfmComponent
-    :className="`rotate ${className ?? ''}`"
+    :className="`bounce ${className ?? ''}`"
     :tokens="children"
     :style="[
       {

--- a/src/components/MfmComponents/Fn/X2.vue
+++ b/src/components/MfmComponents/Fn/X2.vue
@@ -1,6 +1,6 @@
 <template>
   <MfmComponent
-    :className="`rotate ${className ?? ''}`"
+    :className="`x2 ${className ?? ''}`"
     :tokens="children"
     :style="[{ fontSize: '200%' }, style]"
   />

--- a/src/components/MfmComponents/Fn/X3.vue
+++ b/src/components/MfmComponents/Fn/X3.vue
@@ -1,6 +1,6 @@
 <template>
   <MfmComponent
-    :className="`rotate ${className ?? ''}`"
+    :className="`x3 ${className ?? ''}`"
     :tokens="children"
     :style="[{ fontSize: '300%' }, style]"
   />

--- a/src/components/MfmComponents/Fn/X4.vue
+++ b/src/components/MfmComponents/Fn/X4.vue
@@ -1,6 +1,6 @@
 <template>
   <MfmComponent
-    :className="`rotate ${className ?? ''}`"
+    :className="`x4 ${className ?? ''}`"
     :tokens="children"
     :style="[{ fontSize: '400%' }, style]"
   />


### PR DESCRIPTION
## 概要

Bounce.vue, X2.vue, X3.vue, X4.vueの4つのFnコンポーネントで、誤って`rotate`になっていたclassNameを正しい名前に修正しました。

## 変更内容

- Bounce.vue: `rotate` → `bounce`
- X2.vue: `rotate` → `x2`
- X3.vue: `rotate` → `x3`
- X4.vue: `rotate` → `x4`

Closes #38

生成元: [Claude Code](https://claude.ai/code)