### PR TITLE
Font.vueのObject.keys()誤用バグを修正

### DIFF
--- a/src/components/MfmComponents/Fn/Font.vue
+++ b/src/components/MfmComponents/Fn/Font.vue
@@ -2,7 +2,15 @@
   <MfmComponent
     :className="`fg ${className ?? ''}`"
     :tokens="children"
-    :style="[{ fontFamily: Object.keys(token?.args ?? {}) }, style]"
+    :style="[{
+      fontFamily: token?.args?.serif ? 'serif' :
+                  token?.args?.monospace ? 'monospace' :
+                  token?.args?.cursive ? 'cursive' :
+                  token?.args?.fantasy ? 'fantasy' :
+                  token?.args?.emoji ? 'emoji' :
+                  token?.args?.math ? 'math' :
+                  'sans-serif'
+    }, style]"
   />
 </template>
 


### PR DESCRIPTION
## 概要

Font.vueで`Object.keys(token.args)`を使用していたバグを修正しました。本家Misskeyの実装に合わせて、`font-family`プロパティをserif/monospace/cursive/fantasy/emoji/mathから選択する正しい実装に変更しました。

## 変更内容

- `Object.keys(token.args)`を三項演算子による条件分岐に変更
- サポートするフォントタイプ：serif, monospace, cursive, fantasy, emoji, math
- デフォルトはsans-serifを使用

Closes #22

Generated with [Claude Code](https://claude.ai/code)