### PR TITLE
Scale.vueのclassNameを修正し最大値制限を追加

### DIFF
--- a/src/components/MfmComponents/Fn/Scale.vue
+++ b/src/components/MfmComponents/Fn/Scale.vue
@@ -1,10 +1,10 @@
 <template>
   <MfmComponent
-    :className="`rotate ${className ?? ''}`"
+    :className="`scale ${className ?? ''}`"
     :tokens="children"
     :style="[
       {
-        transform: `scale(${token?.args.x}, ${token?.args.y})`
+        transform: `scale(${Math.min(token?.args.x ?? 1, 5)}, ${Math.min(token?.args.y ?? 1, 5)})`
       },
       style
     ]"


### PR DESCRIPTION
## 概要

Scale.vueの2つの問題を修正しました:

1. classNameが`rotate`になっていた問題を`scale`に修正
2. 本家Misskeyと同様に最大5倍までの制限を実装

## 変更内容

- classNameを`rotate`から`scale`に修正
- `Math.min`を使用してx, yそれぞれに最大値5の制限を適用

Fixes #26

Generated with [Claude Code](https://claude.ai/code)