### PR TITLE
tsconfig と Vite に @ エイリアスを追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
 
+    /* Path aliases */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/vite.config.docs.ts
+++ b/vite.config.docs.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "/mfm-renderer",
   plugins: [vue()],
+
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
 
   build: {
     outDir: "docs",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
+
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
 
   build: {
     outDir: "dist",


### PR DESCRIPTION
### 概要

tsconfig.json と Vite の設定ファイルに `@` エイリアスを追加し、`src` ディレクトリへのインポートを簡潔にしました。

### 変更内容

- tsconfig.json に `baseUrl` と `paths` を追加
- vite.config.ts に `resolve.alias` を追加
- vite.config.docs.ts に `resolve.alias` を追加

Closes #45

---

Generated with [Claude Code](https://claude.ai/code)