### PR TITLE
fix: Blur.vueから不要なfontFamilyプロパティを削除

### DIFF
--- a/src/components/MfmComponents/Fn/Blur.vue
+++ b/src/components/MfmComponents/Fn/Blur.vue
@@ -2,7 +2,7 @@
   <MfmComponent
     :className="`blur ${className ?? ''}`"
     :tokens="children"
-    :style="[{ fontFamily: Object.keys(token?.args ?? {}) }, style]"
+    :style="style"
   />
 </template>
 


### PR DESCRIPTION
## 概要

Blur.vueに誤って設定されていた不要なfontFamilyプロパティを削除しました。

## 変更内容

- `src/components/MfmComponents/Fn/Blur.vue`から不要な`fontFamily`プロパティを削除

## 背景

Font.vueからのコピペミスと思われる不要なプロパティが設定されていました。Blurのスタイル（filter: blur）はstyleブロックで正しく実装されています。

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)