### PR TITLE
fix: Spin.vueのアニメーションプロパティをMisskey実装に合わせて修正

### DIFF
--- a/src/components/MfmComponents/Fn/Spin.vue
+++ b/src/components/MfmComponents/Fn/Spin.vue
@@ -14,7 +14,9 @@
     :tokens="children"
     :style="[
       {
-        animation: `${validTime(token?.args.speed) ?? '1.5s'} linear ${validTime(token?.args.delay) ?? '0s'} infinite ${animationDirection} none running ${animationName}`
+        animation: `${animationName} ${validTime(token?.args.speed) ?? '1.5s'} linear infinite`,
+        animationDirection: animationDirection,
+        animationDelay: validTime(token?.args.delay) ?? '0s'
       },
       style
     ]"


### PR DESCRIPTION
### 概要

Spin.vueのx/yとleft/alternateの組み合わせが正しく動作するように、CSSアニメーションプロパティの設定方法をMisskeyの元実装に合わせて修正しました。

### 変更内容

- `animation`ショートハンドプロパティから個別のCSSプロパティに変更
- `animation`: アニメーション名、速度、タイミング関数、反復回数
- `animationDirection`: 方向（normal/reverse/alternate）
- `animationDelay`: 遅延時間

これにより以下の組み合わせが正しく動作するようになります:
- `$[spin.x,left]`
- `$[spin.x,alternate]`
- `$[spin.y,left]`
- `$[spin.y,alternate]`

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)